### PR TITLE
fix

### DIFF
--- a/xFC2.js
+++ b/xFC2.js
@@ -186,6 +186,9 @@ function writelime(datname,dattext){
              if(datname.match(/匿名 \((\d+)?\)/)){
                datname="匿名";
              }
+           }else{
+             var temp = datname.match(/\((\d+)?\)/);
+             datname = "匿名 " + temp[0];
            }
            datname=fc2s[0]+datname+fc2s[1];
            var channelObject = findChannel(mychan);


### PR DESCRIPTION
FC2ライブの仕様変更により名前を取得すると"匿名(X)"から"匿名<span class="aid">(X)</span>"に変わってしまったため抜き出す処理を追加